### PR TITLE
Feat: Adding dev-deployment from CI & fix lazy-loading overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   # Secret scanning  (all branches)
   secrets:
     name: Secret Scanning
+    if: github.event_name != 'pull_request' || (github.head_ref != 'develop' && github.head_ref != 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
   # Backend: lint + type-check  (all branches)
   backend-lint:
     name: "Backend: Lint & Type Check"
+    if: github.event_name != 'pull_request' || (github.head_ref != 'develop' && github.head_ref != 'main')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -57,6 +59,7 @@ jobs:
   # Frontend: lint + type-check  (all branches)
   frontend-lint:
     name: "Frontend: Lint & Type Check"
+    if: github.event_name != 'pull_request' || (github.head_ref != 'develop' && github.head_ref != 'main')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -87,10 +90,11 @@ jobs:
     name: "Backend: Tests (Docker)"
     needs: [backend-lint]
     if: >-
-      github.ref == 'refs/heads/develop' ||
-      github.ref == 'refs/heads/main' ||
-      github.base_ref == 'develop' ||
-      github.base_ref == 'main'
+      (github.event_name != 'pull_request' || (github.head_ref != 'develop' && github.head_ref != 'main')) &&
+      (github.ref == 'refs/heads/develop' ||
+       github.ref == 'refs/heads/main' ||
+       github.base_ref == 'develop' ||
+       github.base_ref == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -173,7 +177,9 @@ jobs:
   docker-build:
     name: "Docker: Production Build"
     needs: [backend-lint, frontend-lint]
-    if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+    if: >-
+      (github.event_name != 'pull_request' || (github.head_ref != 'develop' && github.head_ref != 'main')) &&
+      (github.ref == 'refs/heads/main' || github.base_ref == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,107 @@
+name: Deploy Dev
+
+# Manual-only deploy to the dev Azure environment.
+#
+# This workflow is intentionally NOT triggered by push events. The lint /
+# type-check / test jobs in ci.yml run on every push to develop, but the
+# actual dev deployment (which includes destroying & re-seeding the dev
+# database from prod) only fires when a human clicks "Run workflow" here.
+#
+# Prod data safety:
+#   * The OIDC identity used here is `id-cicd-stacnotator-dev-westeurope`,
+#     federated only for `repo:RAAPID-ORG/stacnotator:ref:refs/heads/develop`
+#     and scoped to the dev resource group. It has zero access to prod.
+#   * Prod credentials used for the dump come from secrets that have been
+#     mirrored into the DEV Key Vault (one-time manual setup, see
+#     azure_deploy/README.md). They belong to a SELECT-only Postgres role
+#     on prod. The sync script aborts if that role has any write privilege.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sync_prod_db:
+        description: "Sync prod DB to dev before deploy (read-only on prod)"
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy-dev:
+    if: github.ref == 'refs/heads/develop'
+    runs-on: [self-hosted, linux, x64, azure]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Azure Login via OIDC (dev identity)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID_DEV }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install postgresql client (for sync)
+        if: ${{ inputs.sync_prod_db }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client
+
+      - name: Discover dev Key Vault
+        id: kv
+        run: |
+          KV_NAME=$(az keyvault list -g "${{ secrets.AZURE_RESOURCE_GROUP_DEV }}" --query "[0].name" -o tsv)
+          [ -z "$KV_NAME" ] && { echo "::error::No Key Vault in dev RG"; exit 1; }
+          echo "::add-mask::$KV_NAME"
+          echo "kv_name=$KV_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Sync prod DB → dev (read-only on prod)
+        if: ${{ inputs.sync_prod_db }}
+        env:
+          CI: "true"
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_DEV }}
+        run: |
+          set -e
+          KV="${{ steps.kv.outputs.kv_name }}"
+
+          fetch_secret() {
+            local v
+            v=$(az keyvault secret show --vault-name "$KV" --name "$1" --query value -o tsv 2>/dev/null)
+            [ -n "$v" ] && printf '::add-mask::%s\n' "$v" >&2
+            printf '%s' "$v"
+          }
+
+          # Prod-readonly creds, mirrored from prod into the dev KV (one-time setup).
+          PROD_PG_HOST=$(fetch_secret prod-readonly-db-host);     export PROD_PG_HOST
+          PROD_PG_USER=$(fetch_secret prod-readonly-db-user);     export PROD_PG_USER
+          PROD_PG_PASS=$(fetch_secret prod-readonly-db-password); export PROD_PG_PASS
+          PROD_PG_DBNAME=$(fetch_secret prod-readonly-db-name);   export PROD_PG_DBNAME
+
+          # Dev admin creds for the drop/restore on the dev side.
+          DEV_PG_HOST=$(fetch_secret stacnotator-dev-postgres-host);           export DEV_PG_HOST
+          DEV_PG_PASS=$(fetch_secret stacnotator-dev-postgres-admin-password); export DEV_PG_PASS
+          export DEV_PG_USER=psqladmin
+          export DEV_PG_DBNAME=stacnotator
+
+          ./azure_deploy/sync-prod-data-to-dev.sh
+
+      - name: Deploy to Azure (dev)
+        env:
+          CI: "true"
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP_DEV }}
+          EE_SERVICE_ACCOUNT: ${{ secrets.EE_SERVICE_ACCOUNT_DEV }}
+        run: ./azure_deploy/deploy-app.sh dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,16 +11,16 @@ name: Deploy Dev
 #   * The OIDC identity used here is `id-cicd-stacnotator-dev-westeurope`,
 #     federated only for `repo:RAAPID-ORG/stacnotator:ref:refs/heads/develop`
 #     and scoped to the dev resource group. It has zero access to prod.
-#   * Prod credentials used for the dump come from secrets that have been
-#     mirrored into the DEV Key Vault (one-time manual setup, see
-#     azure_deploy/README.md). They belong to a SELECT-only Postgres role
-#     on prod. The sync script aborts if that role has any write privilege.
+#   * Prod credentials used for the dump come from secrets mirrored into the
+#     DEV Key Vault (one-time manual setup, see azure_deploy/README.md). The
+#     sync script only calls `pg_dump` against the source and aborts if the
+#     source/target hosts match or the target doesn't look like the dev server.
 
 on:
   workflow_dispatch:
     inputs:
       sync_prod_db:
-        description: "Sync prod DB to dev before deploy (read-only on prod)"
+        description: "Sync prod DB to dev before deploy (pg_dump only)"
         required: true
         default: true
         type: boolean
@@ -69,7 +69,7 @@ jobs:
           echo "::add-mask::$KV_NAME"
           echo "kv_name=$KV_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Sync prod DB → dev (read-only on prod)
+      - name: Sync prod DB → dev
         if: ${{ inputs.sync_prod_db }}
         env:
           CI: "true"
@@ -85,11 +85,11 @@ jobs:
             printf '%s' "$v"
           }
 
-          # Prod-readonly creds, mirrored from prod into the dev KV (one-time setup).
-          PROD_PG_HOST=$(fetch_secret prod-readonly-db-host);     export PROD_PG_HOST
-          PROD_PG_USER=$(fetch_secret prod-readonly-db-user);     export PROD_PG_USER
-          PROD_PG_PASS=$(fetch_secret prod-readonly-db-password); export PROD_PG_PASS
-          PROD_PG_DBNAME=$(fetch_secret prod-readonly-db-name);   export PROD_PG_DBNAME
+          # Prod DB creds, mirrored from prod into the dev KV (one-time setup).
+          PROD_PG_HOST=$(fetch_secret prod-db-host);     export PROD_PG_HOST
+          PROD_PG_USER=$(fetch_secret prod-db-user);     export PROD_PG_USER
+          PROD_PG_PASS=$(fetch_secret prod-db-password); export PROD_PG_PASS
+          PROD_PG_DBNAME=$(fetch_secret prod-db-name);   export PROD_PG_DBNAME
 
           # Dev admin creds for the drop/restore on the dev side.
           DEV_PG_HOST=$(fetch_secret stacnotator-dev-postgres-host);           export DEV_PG_HOST

--- a/azure_deploy/README.md
+++ b/azure_deploy/README.md
@@ -38,7 +38,7 @@ profile for the tiler — currently disabled in both envs; flip the flag in
 - **Docker** installed for building images
 - **Node.js** installed for building the frontend
 
-## First-Time Setup (ONE TIME per environment)
+## First-Time Setup for local deployments (ONE TIME per environment)
 
 ```bash
 # 1. Create environment config
@@ -104,6 +104,50 @@ This will:
 2. Drop and recreate the dev database
 3. Restore the dump into dev
 4. Run migrations via the dev backend container app (typically a no-op now that the container also runs `alembic upgrade head` on startup, but kept as a safety net in case the dev replica wasn't restarted after the restore).
+
+### Running this from CI (Deploy Dev workflow)
+
+The `Deploy Dev` GitHub Actions workflow (`.github/workflows/deploy-dev.yml`) runs the same sync + deploy on the self-hosted Azure runner when you click **Run workflow** in the Actions tab. It is manual-only: pushing to `develop` runs lint/tests but does NOT deploy or touch any database.
+
+The CI path uses a dedicated **read-only Postgres role on prod** so it is physically impossible for the workflow to alter prod data. The dev CI's OIDC identity has no access to prod resources; the prod-readonly credentials are mirrored into the **dev** Key Vault, where the dev identity can read them.
+
+#### One-time setup (do this before the first CI dev deploy)
+
+1. **Create the prod-readonly Postgres role.** Connect to prod over VPN (e.g. via `psql` with the admin password from the prod Key Vault) and run:
+
+   ```sql
+   CREATE USER ci_readonly WITH PASSWORD '<generate-a-strong-password>';
+   GRANT CONNECT ON DATABASE stacnotator TO ci_readonly;
+   GRANT USAGE ON SCHEMA public TO ci_readonly;
+   GRANT SELECT ON ALL TABLES IN SCHEMA public TO ci_readonly;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ci_readonly;
+   -- No INSERT/UPDATE/DELETE/TRUNCATE, no CREATE on the DB. The sync script
+   -- verifies this on every run and refuses to start if any write priv exists.
+   ```
+
+2. **Mirror the credentials into the dev Key Vault.** The dev RG / dev KV names come from `.env.deploy.dev`.
+
+   ```bash
+   DEV_KV=$(az keyvault list -g <dev-rg> --query "[0].name" -o tsv)
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-host     --value '<prod-server>.postgres.database.azure.com'
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-user     --value 'ci_readonly'
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-password --value '<password-from-step-1>'
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-name     --value 'stacnotator'
+   ```
+
+3. **Configure GitHub repo secrets** (Settings → Secrets and variables → Actions):
+
+   | Secret | Value |
+   |---|---|
+   | `AZURE_CLIENT_ID_DEV` | Client ID of `id-cicd-stacnotator-dev-westeurope` (from `az identity show -n id-cicd-stacnotator-dev-westeurope -g <main-platform-rg> --query clientId -o tsv`) |
+   | `AZURE_RESOURCE_GROUP_DEV` | `rg-stacnotator-dev-prod-westeurope` (or whatever the dev RG is named) |
+   | `EE_SERVICE_ACCOUNT_DEV` | Same Earth Engine SA used in `.env.deploy.dev` |
+
+   `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` are shared with the prod workflow and should already exist.
+
+4. **Configure a `dev` GitHub Environment** (optional but recommended) under Settings → Environments. You can add reviewers here as an extra approval gate before the deploy job runs.
+
+After this, hitting **Run workflow** on `Deploy Dev` from the `develop` branch will: pull prod-readonly creds from dev KV → dump prod → drop+restore dev DB → deploy backend/tiler/frontend to dev. The sync step can be turned off via the `sync_prod_db` input on the run form.
 
 ## Scripts
 

--- a/azure_deploy/README.md
+++ b/azure_deploy/README.md
@@ -16,7 +16,7 @@ that runs on container startup is serialized by definition. To scale beyond
 1 replica, also add a `pg_advisory_lock` around `context.run_migrations()`
 in `backend/alembic/env.py` (see note in that file). The deploy script has
 a `TILER_DEDICATED=true` branch that provisions a D16 dedicated workload
-profile for the tiler — currently disabled in both envs; flip the flag in
+profile for the tiler - currently disabled in both envs; flip the flag in
 `deploy-app.sh` if you need it for heavy tile load.
 
 ## Architecture
@@ -77,7 +77,7 @@ The script will:
 2. Build and push Docker images (backend + tiler) to ACR
 3. Create or update Container Apps with KV secret refs (no plaintext credentials)
 4. If `TILER_DEDICATED=true`: add a D16 dedicated workload profile for the tiler. Off by default in both envs; the consumption profile handles current load.
-5. Poll the new backend revision until `healthState=Healthy`. Migrations run as part of container startup (`alembic upgrade head` in the Dockerfile CMD before gunicorn) — a failed migration leaves the new revision unhealthy and Container Apps keeps the previous revision serving 100% traffic (automatic rollback).
+5. Poll the new backend revision until `healthState=Healthy`. Migrations run as part of container startup (`alembic upgrade head` in the Dockerfile CMD before gunicorn) - a failed migration leaves the new revision unhealthy and Container Apps keeps the previous revision serving 100% traffic (automatic rollback).
 6. Build and deploy frontend to Azure Static Web App
 7. Update CORS on backend + tiler
 
@@ -89,7 +89,7 @@ The script will:
 az containerapp exec -n stacnotator-prod-backend -g <rg> --command "alembic current"
 ```
 
-Note that `az containerapp exec` requires a TTY-capable shell — it fails inside non-interactive CI runners. Local interactive terminals are fine.
+Note that `az containerapp exec` requires a TTY-capable shell - it fails inside non-interactive CI runners. Local interactive terminals are fine.
 
 ## Dev Environment with Production Data
 

--- a/azure_deploy/README.md
+++ b/azure_deploy/README.md
@@ -109,33 +109,40 @@ This will:
 
 The `Deploy Dev` GitHub Actions workflow (`.github/workflows/deploy-dev.yml`) runs the same sync + deploy on the self-hosted Azure runner when you click **Run workflow** in the Actions tab. It is manual-only: pushing to `develop` runs lint/tests but does NOT deploy or touch any database.
 
-The CI path uses a dedicated **read-only Postgres role on prod** so it is physically impossible for the workflow to alter prod data. The dev CI's OIDC identity has no access to prod resources; the prod-readonly credentials are mirrored into the **dev** Key Vault, where the dev identity can read them.
+The CI workflow has no Azure access to prod: its OIDC identity is federated only to the **develop** branch and scoped to the dev resource group. To dump prod, the workflow reads prod DB credentials from the **dev** Key Vault, where they are mirrored once during setup.
+
+Safety relies on:
+- The OIDC identity having zero prod RBAC.
+- The workflow being **manual-only** (`workflow_dispatch`).
+- The sync script aborting if source and target hosts match, or if the target host doesn't look like the dev server.
+- The script only calling `pg_dump` against prod — no `psql` execution path writes to the source side.
 
 #### One-time setup (do this before the first CI dev deploy)
 
-1. **Create the prod-readonly Postgres role.** Connect to prod over VPN (e.g. via `psql` with the admin password from the prod Key Vault) and run:
-
-   ```sql
-   CREATE USER ci_readonly WITH PASSWORD '<generate-a-strong-password>';
-   GRANT CONNECT ON DATABASE stacnotator TO ci_readonly;
-   GRANT USAGE ON SCHEMA public TO ci_readonly;
-   GRANT SELECT ON ALL TABLES IN SCHEMA public TO ci_readonly;
-   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ci_readonly;
-   -- No INSERT/UPDATE/DELETE/TRUNCATE, no CREATE on the DB. The sync script
-   -- verifies this on every run and refuses to start if any write priv exists.
-   ```
-
-2. **Mirror the credentials into the dev Key Vault.** The dev RG / dev KV names come from `.env.deploy.dev`.
+1. **Mirror prod DB credentials into the dev Key Vault.** Pull the values from the prod Key Vault (on VPN, with prod RG access) and write them into the dev Key Vault:
 
    ```bash
-   DEV_KV=$(az keyvault list -g <dev-rg> --query "[0].name" -o tsv)
-   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-host     --value '<prod-server>.postgres.database.azure.com'
-   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-user     --value 'ci_readonly'
-   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-password --value '<password-from-step-1>'
-   az keyvault secret set --vault-name "$DEV_KV" --name prod-readonly-db-name     --value 'stacnotator'
+   set -a && source azure_deploy/.env.deploy.prod && set +a
+   PROD_RG="$RESOURCE_GROUP"
+   PROD_KV=$(az keyvault list -g "$PROD_RG" --query "[0].name" -o tsv)
+
+   PROD_HOST=$(az keyvault secret show --vault-name "$PROD_KV" --name stacnotator-prod-postgres-host           --query value -o tsv)
+   PROD_PASS=$(az keyvault secret show --vault-name "$PROD_KV" --name stacnotator-prod-postgres-admin-password --query value -o tsv)
+   PROD_CONN=$(az keyvault secret show --vault-name "$PROD_KV" --name stacnotator-prod-db-connection-string    --query value -o tsv)
+   PROD_USER=$(echo "$PROD_CONN" | sed -n 's|.*://\([^:]*\):.*|\1|p')
+
+   set -a && source azure_deploy/.env.deploy.dev && set +a
+   DEV_KV=$(az keyvault list -g "$RESOURCE_GROUP" --query "[0].name" -o tsv)
+
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-db-host     --value "$PROD_HOST"
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-db-user     --value "$PROD_USER"
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-db-password --value "$PROD_PASS"
+   az keyvault secret set --vault-name "$DEV_KV" --name prod-db-name     --value 'stacnotator'
    ```
 
-3. **Configure GitHub repo secrets** (Settings → Secrets and variables → Actions):
+   Re-run this if the prod admin password is rotated.
+
+2. **Configure GitHub repo secrets** (Settings → Secrets and variables → Actions):
 
    | Secret | Value |
    |---|---|
@@ -145,9 +152,9 @@ The CI path uses a dedicated **read-only Postgres role on prod** so it is physic
 
    `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` are shared with the prod workflow and should already exist.
 
-4. **Configure a `dev` GitHub Environment** (optional but recommended) under Settings → Environments. You can add reviewers here as an extra approval gate before the deploy job runs.
+3. **Configure a `dev` GitHub Environment** (optional but recommended) under Settings → Environments. You can add reviewers here as an extra approval gate before the deploy job runs.
 
-After this, hitting **Run workflow** on `Deploy Dev` from the `develop` branch will: pull prod-readonly creds from dev KV → dump prod → drop+restore dev DB → deploy backend/tiler/frontend to dev. The sync step can be turned off via the `sync_prod_db` input on the run form.
+After this, hitting **Run workflow** on `Deploy Dev` from the `develop` branch will: pull prod DB creds from dev KV → `pg_dump` prod → drop+restore dev DB → deploy backend/tiler/frontend to dev. The sync step can be turned off via the `sync_prod_db` input on the run form.
 
 ## Scripts
 

--- a/azure_deploy/sync-prod-data-to-dev.sh
+++ b/azure_deploy/sync-prod-data-to-dev.sh
@@ -2,14 +2,14 @@
 #
 # Sync Production Data to Dev Azure Environment
 #
-# Dumps the production database (via a read-only Postgres role) and restores
-# it into the dev Azure Postgres, then runs migrations so the dev environment
-# matches prod data with the latest schema.
+# Dumps the production database and restores it into the dev Azure Postgres,
+# then runs migrations so the dev environment matches prod data with the
+# latest schema.
 #
 # IMPORTANT - PROD DATA SAFETY:
-#   - The dump uses a designated read-only Postgres user on prod.
-#   - The script aborts if that user has ANY write/DDL privileges on prod tables.
+#   - The only command run against prod is pg_dump (no writes).
 #   - The script aborts if source (prod) host/RG equal target (dev) host/RG.
+#   - The target host must look like the dev server (contains "stacnotator-dev").
 #   - Dev (target) is ALWAYS the side that gets dropped/recreated, never prod.
 #
 # Two modes:
@@ -19,7 +19,7 @@
 #
 #   2) CI (set CI=true): no prompts, no prod KV access, all credentials come
 #      from environment variables (the workflow populates them from the dev
-#      Key Vault, where prod-readonly creds have been mirrored once).
+#      Key Vault, where prod DB creds have been mirrored once).
 #
 #      Required env vars in CI mode:
 #        PROD_PG_HOST, PROD_PG_USER, PROD_PG_PASS, PROD_PG_DBNAME
@@ -146,33 +146,6 @@ case "$DEV_PG_HOST" in
     *) abort "DEV_PG_HOST ($DEV_PG_HOST) does not look like a dev server. Refusing to run." ;;
 esac
 
-# 3. Source (prod) user must be read-only. Probe pg_catalog for any write
-#    privilege on any table in the target DB. If the user can write, refuse.
-echo -e "${YELLOW}Verifying prod user is read-only...${NC}"
-WRITE_PRIVS=$(PGPASSWORD="$PROD_PG_PASS" psql \
-    --host="$PROD_PG_HOST" --port=5432 \
-    --username="$PROD_PG_USER" --dbname="$PROD_PG_DBNAME" \
-    -tAc "SELECT count(*) FROM information_schema.table_privileges
-          WHERE grantee = current_user
-            AND privilege_type IN ('INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER');" 2>/dev/null || echo "ERR")
-
-if [ "$WRITE_PRIVS" = "ERR" ]; then
-    abort "Could not connect to prod as $PROD_PG_USER@$PROD_PG_HOST/$PROD_PG_DBNAME"
-fi
-if [ "$WRITE_PRIVS" != "0" ]; then
-    abort "Prod user '$PROD_PG_USER' has $WRITE_PRIVS write privilege(s). Use a SELECT-only role."
-fi
-
-# Also refuse if the user has CREATE on the database (could create/drop schemas).
-CREATE_PRIV=$(PGPASSWORD="$PROD_PG_PASS" psql \
-    --host="$PROD_PG_HOST" --port=5432 \
-    --username="$PROD_PG_USER" --dbname="$PROD_PG_DBNAME" \
-    -tAc "SELECT has_database_privilege(current_user, current_database(), 'CREATE');" 2>/dev/null || echo "ERR")
-if [ "$CREATE_PRIV" = "t" ]; then
-    abort "Prod user '$PROD_PG_USER' has CREATE on database. Use a SELECT-only role."
-fi
-
-echo -e "${GREEN}✓ Prod user verified read-only${NC}"
 echo -e "${GREEN}✓ Source: ${PROD_PG_USER}@${PROD_PG_HOST}/${PROD_PG_DBNAME}${NC}"
 echo -e "${GREEN}✓ Target: ${DEV_PG_USER}@${DEV_PG_HOST}/${DEV_PG_DBNAME}${NC}"
 
@@ -191,7 +164,7 @@ if [ "$CI" != "true" ]; then
 fi
 
 # =============================================================================
-# DUMP PROD (read-only, no writes possible with the verified user)
+# DUMP PROD (pg_dump is read-only by nature)
 # =============================================================================
 
 echo ""

--- a/azure_deploy/sync-prod-data-to-dev.sh
+++ b/azure_deploy/sync-prod-data-to-dev.sh
@@ -2,17 +2,33 @@
 #
 # Sync Production Data to Dev Azure Environment
 #
-# Dumps the production database and restores it into the dev Azure Postgres,
-# then runs migrations so the dev environment matches prod data with latest schema.
+# Dumps the production database (via a read-only Postgres role) and restores
+# it into the dev Azure Postgres, then runs migrations so the dev environment
+# matches prod data with the latest schema.
 #
-# Prerequisites:
+# IMPORTANT - PROD DATA SAFETY:
+#   - The dump uses a designated read-only Postgres user on prod.
+#   - The script aborts if that user has ANY write/DDL privileges on prod tables.
+#   - The script aborts if source (prod) host/RG equal target (dev) host/RG.
+#   - Dev (target) is ALWAYS the side that gets dropped/recreated, never prod.
+#
+# Two modes:
+#
+#   1) Interactive (default): reads creds from prod Key Vault, prompts to confirm.
+#      Used by humans on VPN.
+#
+#   2) CI (set CI=true): no prompts, no prod KV access, all credentials come
+#      from environment variables (the workflow populates them from the dev
+#      Key Vault, where prod-readonly creds have been mirrored once).
+#
+#      Required env vars in CI mode:
+#        PROD_PG_HOST, PROD_PG_USER, PROD_PG_PASS, PROD_PG_DBNAME
+#        DEV_PG_HOST,  DEV_PG_USER,  DEV_PG_PASS,  DEV_PG_DBNAME
+#        RESOURCE_GROUP (dev RG, for the post-restore migration step)
+#
+# Prerequisites (interactive mode):
 #   - Logged into Azure CLI (az login)
-#   - Connected to your organization's VPN
-#   - Your IP whitelisted on BOTH prod and dev Azure Postgres Flexible Servers
-#   - Dev infrastructure deployed via Terraform (RG, DB, KV exist)
-#
-# Usage:
-#   ./azure_deploy/sync-prod-data-to-dev.sh
+#   - On VPN, IP whitelisted on BOTH prod and dev Postgres servers
 #
 
 set -e
@@ -25,176 +41,204 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-if ! az account show &>/dev/null; then
-    echo -e "${RED}Error: Not logged in to Azure. Run 'az login' first.${NC}"
-    exit 1
+abort() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+
+if [ "$CI" = "true" ]; then
+    # ---------------- CI MODE ----------------
+    # All credentials must come from the environment. No prod Azure CLI calls.
+
+    for v in PROD_PG_HOST PROD_PG_USER PROD_PG_PASS PROD_PG_DBNAME \
+             DEV_PG_HOST DEV_PG_USER DEV_PG_PASS DEV_PG_DBNAME RESOURCE_GROUP; do
+        [ -z "${!v}" ] && abort "$v not set (required in CI mode)"
+    done
+
+    DEV_RG="$RESOURCE_GROUP"
+
+    # Mask secrets in workflow logs (no-op if not running under Actions).
+    for s in "$PROD_PG_PASS" "$DEV_PG_PASS" "$PROD_PG_HOST" "$DEV_PG_HOST" \
+             "$PROD_PG_USER" "$DEV_PG_USER"; do
+        [ -n "$s" ] && echo "::add-mask::$s"
+    done
+else
+    # ---------------- INTERACTIVE MODE ----------------
+    if ! az account show &>/dev/null; then
+        abort "Not logged in to Azure. Run 'az login' first."
+    fi
+
+    [ -f "$SCRIPT_DIR/.env.deploy.prod" ] && set -a && source "$SCRIPT_DIR/.env.deploy.prod" && set +a
+    PROD_RG="$RESOURCE_GROUP"
+    [ -z "$PROD_RG" ] && abort "RESOURCE_GROUP not set. Check .env.deploy.prod"
+
+    echo -e "${YELLOW}Looking up prod Postgres server...${NC}"
+    PROD_PG_SERVER=$(az postgres flexible-server list \
+        --resource-group "$PROD_RG" --query "[0].name" -o tsv 2>/dev/null || true)
+    [ -z "$PROD_PG_SERVER" ] && abort "No Postgres Flexible Server found in $PROD_RG"
+    PROD_PG_HOST="${PROD_PG_SERVER}.postgres.database.azure.com"
+
+    PROD_KV_NAME=$(az keyvault list -g "$PROD_RG" --query "[0].name" -o tsv 2>/dev/null || true)
+    [ -z "$PROD_KV_NAME" ] && abort "No Key Vault found in $PROD_RG"
+
+    PROD_PG_PASS=$(az keyvault secret show --vault-name "$PROD_KV_NAME" --name "stacnotator-prod-postgres-admin-password" --query "value" -o tsv 2>/dev/null || true)
+    PROD_PG_HOST_KV=$(az keyvault secret show --vault-name "$PROD_KV_NAME" --name "stacnotator-prod-postgres-host" --query "value" -o tsv 2>/dev/null || true)
+    PROD_CONN_STR=$(az keyvault secret show --vault-name "$PROD_KV_NAME" --name "stacnotator-prod-db-connection-string" --query "value" -o tsv 2>/dev/null || true)
+    if [ -n "$PROD_CONN_STR" ]; then
+        PROD_PG_USER=$(echo "$PROD_CONN_STR" | sed -n 's|.*://\([^:]*\):.*|\1|p')
+        PROD_PG_DBNAME=$(echo "$PROD_CONN_STR" | sed -n 's|.*/\([^?]*\).*|\1|p')
+    fi
+    [ -n "$PROD_PG_HOST_KV" ] && PROD_PG_HOST="$PROD_PG_HOST_KV"
+
+    [ -z "$PROD_PG_USER" ] && read -p "Enter prod DB username: " PROD_PG_USER
+    if [ -z "$PROD_PG_PASS" ]; then
+        read -sp "Enter prod DB password: " PROD_PG_PASS
+        echo ""
+    fi
+    PROD_PG_DBNAME=${PROD_PG_DBNAME:-stacnotator}
+
+    [ -f "$SCRIPT_DIR/.env.deploy.dev" ] && set -a && source "$SCRIPT_DIR/.env.deploy.dev" && set +a
+    DEV_RG="$RESOURCE_GROUP"
+    [ -z "$DEV_RG" ] && abort "RESOURCE_GROUP not set. Check .env.deploy.dev"
+
+    echo -e "${YELLOW}Looking up dev Postgres server...${NC}"
+    DEV_PG_SERVER=$(az postgres flexible-server list \
+        --resource-group "$DEV_RG" --query "[0].name" -o tsv 2>/dev/null || true)
+    [ -z "$DEV_PG_SERVER" ] && abort "No Postgres Flexible Server found in $DEV_RG"
+    DEV_PG_HOST="${DEV_PG_SERVER}.postgres.database.azure.com"
+
+    DEV_KV_NAME=$(az keyvault list -g "$DEV_RG" --query "[0].name" -o tsv 2>/dev/null || true)
+    [ -z "$DEV_KV_NAME" ] && abort "No Key Vault found in $DEV_RG"
+
+    DEV_PG_PASS=$(az keyvault secret show --vault-name "$DEV_KV_NAME" --name "stacnotator-dev-postgres-admin-password" --query "value" -o tsv 2>/dev/null || true)
+    DEV_PG_HOST_KV=$(az keyvault secret show --vault-name "$DEV_KV_NAME" --name "stacnotator-dev-postgres-host" --query "value" -o tsv 2>/dev/null || true)
+    DEV_CONN_STR=$(az keyvault secret show --vault-name "$DEV_KV_NAME" --name "stacnotator-dev-db-connection-string" --query "value" -o tsv 2>/dev/null || true)
+    if [ -n "$DEV_CONN_STR" ]; then
+        DEV_PG_USER=$(echo "$DEV_CONN_STR" | sed -n 's|.*://\([^:]*\):.*|\1|p')
+        DEV_PG_DBNAME=$(echo "$DEV_CONN_STR" | sed -n 's|.*/\([^?]*\).*|\1|p')
+    fi
+    [ -n "$DEV_PG_HOST_KV" ] && DEV_PG_HOST="$DEV_PG_HOST_KV"
+
+    [ -z "$DEV_PG_USER" ] && DEV_PG_USER="${PROD_PG_USER}"
+    if [ -z "$DEV_PG_PASS" ]; then
+        read -sp "Enter dev DB password: " DEV_PG_PASS
+        echo ""
+    fi
+    DEV_PG_DBNAME=${DEV_PG_DBNAME:-stacnotator}
 fi
 
-# Load prod config
+# =============================================================================
+# SAFETY GUARDS - protect prod from any possible mishap
+# =============================================================================
 
-[ -f "$SCRIPT_DIR/.env.deploy.prod" ] && set -a && source "$SCRIPT_DIR/.env.deploy.prod" && set +a
-PROD_RG="$RESOURCE_GROUP"
-
-if [ -z "$PROD_RG" ]; then
-    echo -e "${RED}Error: RESOURCE_GROUP not set. Check .env.deploy.prod${NC}"
-    exit 1
+# 1. Source and target must not be the same server / DB / RG.
+if [ "$PROD_PG_HOST" = "$DEV_PG_HOST" ]; then
+    abort "PROD_PG_HOST == DEV_PG_HOST ($PROD_PG_HOST). Refusing to run."
+fi
+if [ -n "$PROD_RG" ] && [ -n "$DEV_RG" ] && [ "$PROD_RG" = "$DEV_RG" ]; then
+    abort "PROD and DEV resource groups are identical ($PROD_RG). Refusing to run."
+fi
+if [ "$PROD_PG_HOST/$PROD_PG_DBNAME" = "$DEV_PG_HOST/$DEV_PG_DBNAME" ]; then
+    abort "Source and target database identifiers are identical. Refusing to run."
 fi
 
-# Discover prod Postgres
-echo -e "${YELLOW}Looking up prod Postgres server...${NC}"
-PROD_PG_SERVER=$(az postgres flexible-server list \
-    --resource-group "$PROD_RG" \
-    --query "[0].name" -o tsv 2>/dev/null || true)
+# 2. Target (dev) host must look like the dev server (defense in depth against
+#    swapped env vars). The dev server name contains "stacnotator-dev".
+case "$DEV_PG_HOST" in
+    *stacnotator-dev*) ;;
+    *) abort "DEV_PG_HOST ($DEV_PG_HOST) does not look like a dev server. Refusing to run." ;;
+esac
 
-if [ -z "$PROD_PG_SERVER" ]; then
-    echo -e "${RED}Error: No Postgres Flexible Server found in $PROD_RG${NC}"
-    exit 1
+# 3. Source (prod) user must be read-only. Probe pg_catalog for any write
+#    privilege on any table in the target DB. If the user can write, refuse.
+echo -e "${YELLOW}Verifying prod user is read-only...${NC}"
+WRITE_PRIVS=$(PGPASSWORD="$PROD_PG_PASS" psql \
+    --host="$PROD_PG_HOST" --port=5432 \
+    --username="$PROD_PG_USER" --dbname="$PROD_PG_DBNAME" \
+    -tAc "SELECT count(*) FROM information_schema.table_privileges
+          WHERE grantee = current_user
+            AND privilege_type IN ('INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER');" 2>/dev/null || echo "ERR")
+
+if [ "$WRITE_PRIVS" = "ERR" ]; then
+    abort "Could not connect to prod as $PROD_PG_USER@$PROD_PG_HOST/$PROD_PG_DBNAME"
+fi
+if [ "$WRITE_PRIVS" != "0" ]; then
+    abort "Prod user '$PROD_PG_USER' has $WRITE_PRIVS write privilege(s). Use a SELECT-only role."
 fi
 
-PROD_PG_HOST="${PROD_PG_SERVER}.postgres.database.azure.com"
-
-# Get prod credentials from Key Vault
-PROD_KV_NAME=$(az keyvault list -g "$PROD_RG" --query "[0].name" -o tsv 2>/dev/null || true)
-[ -z "$PROD_KV_NAME" ] && echo -e "${RED}Error: No Key Vault found in $PROD_RG${NC}" && exit 1
-
-PROD_PG_PASS=$(az keyvault secret show --vault-name "$PROD_KV_NAME" --name "stacnotator-prod-postgres-admin-password" --query "value" -o tsv 2>/dev/null || true)
-PROD_PG_HOST_KV=$(az keyvault secret show --vault-name "$PROD_KV_NAME" --name "stacnotator-prod-postgres-host" --query "value" -o tsv 2>/dev/null || true)
-PROD_CONN_STR=$(az keyvault secret show --vault-name "$PROD_KV_NAME" --name "stacnotator-prod-db-connection-string" --query "value" -o tsv 2>/dev/null || true)
-
-if [ -n "$PROD_CONN_STR" ]; then
-    PROD_PG_USER=$(echo "$PROD_CONN_STR" | sed -n 's|.*://\([^:]*\):.*|\1|p')
-    PROD_PG_DBNAME=$(echo "$PROD_CONN_STR" | sed -n 's|.*/\([^?]*\).*|\1|p')
+# Also refuse if the user has CREATE on the database (could create/drop schemas).
+CREATE_PRIV=$(PGPASSWORD="$PROD_PG_PASS" psql \
+    --host="$PROD_PG_HOST" --port=5432 \
+    --username="$PROD_PG_USER" --dbname="$PROD_PG_DBNAME" \
+    -tAc "SELECT has_database_privilege(current_user, current_database(), 'CREATE');" 2>/dev/null || echo "ERR")
+if [ "$CREATE_PRIV" = "t" ]; then
+    abort "Prod user '$PROD_PG_USER' has CREATE on database. Use a SELECT-only role."
 fi
 
-[ -n "$PROD_PG_HOST_KV" ] && PROD_PG_HOST="$PROD_PG_HOST_KV"
+echo -e "${GREEN}✓ Prod user verified read-only${NC}"
+echo -e "${GREEN}✓ Source: ${PROD_PG_USER}@${PROD_PG_HOST}/${PROD_PG_DBNAME}${NC}"
+echo -e "${GREEN}✓ Target: ${DEV_PG_USER}@${DEV_PG_HOST}/${DEV_PG_DBNAME}${NC}"
 
-# Fallback prompts for prod
-[ -z "$PROD_PG_USER" ] && read -p "Enter prod DB username: " PROD_PG_USER
-if [ -z "$PROD_PG_PASS" ]; then
-    read -sp "Enter prod DB password: " PROD_PG_PASS
+DUMP_FILE="${TMPDIR:-/tmp}/stacnotator_prod_to_dev_dump.sql"
+
+if [ "$CI" != "true" ]; then
     echo ""
-fi
-PROD_PG_DBNAME=${PROD_PG_DBNAME:-stacnotator}
-
-echo -e "${GREEN}✓ Prod: ${PROD_PG_USER}@${PROD_PG_HOST}/${PROD_PG_DBNAME}${NC}"
-
-# Load dev config
-
-[ -f "$SCRIPT_DIR/.env.deploy.dev" ] && set -a && source "$SCRIPT_DIR/.env.deploy.dev" && set +a
-DEV_RG="$RESOURCE_GROUP"
-
-if [ -z "$DEV_RG" ]; then
-    echo -e "${RED}Error: RESOURCE_GROUP not set. Check .env.deploy.dev${NC}"
-    exit 1
-fi
-
-echo -e "${YELLOW}Looking up dev Postgres server...${NC}"
-DEV_PG_SERVER=$(az postgres flexible-server list \
-    --resource-group "$DEV_RG" \
-    --query "[0].name" -o tsv 2>/dev/null || true)
-
-if [ -z "$DEV_PG_SERVER" ]; then
-    echo -e "${RED}Error: No Postgres Flexible Server found in $DEV_RG${NC}"
-    exit 1
-fi
-
-DEV_PG_HOST="${DEV_PG_SERVER}.postgres.database.azure.com"
-
-# Get dev credentials from Key Vault
-DEV_KV_NAME=$(az keyvault list -g "$DEV_RG" --query "[0].name" -o tsv 2>/dev/null || true)
-[ -z "$DEV_KV_NAME" ] && echo -e "${RED}Error: No Key Vault found in $DEV_RG${NC}" && exit 1
-
-DEV_PG_PASS=$(az keyvault secret show --vault-name "$DEV_KV_NAME" --name "stacnotator-dev-postgres-admin-password" --query "value" -o tsv 2>/dev/null || true)
-DEV_PG_HOST_KV=$(az keyvault secret show --vault-name "$DEV_KV_NAME" --name "stacnotator-dev-postgres-host" --query "value" -o tsv 2>/dev/null || true)
-DEV_CONN_STR=$(az keyvault secret show --vault-name "$DEV_KV_NAME" --name "stacnotator-dev-db-connection-string" --query "value" -o tsv 2>/dev/null || true)
-
-if [ -n "$DEV_CONN_STR" ]; then
-    DEV_PG_USER=$(echo "$DEV_CONN_STR" | sed -n 's|.*://\([^:]*\):.*|\1|p')
-    DEV_PG_DBNAME=$(echo "$DEV_CONN_STR" | sed -n 's|.*/\([^?]*\).*|\1|p')
-fi
-
-[ -n "$DEV_PG_HOST_KV" ] && DEV_PG_HOST="$DEV_PG_HOST_KV"
-
-# Fallback prompts for dev
-[ -z "$DEV_PG_USER" ] && DEV_PG_USER="${PROD_PG_USER}"
-if [ -z "$DEV_PG_PASS" ]; then
-    read -sp "Enter dev DB password: " DEV_PG_PASS
+    echo -e "${BLUE}Sync Plan${NC}"
+    echo -e "  Source (prod): ${YELLOW}${PROD_PG_USER}@${PROD_PG_HOST}/${PROD_PG_DBNAME}${NC}"
+    echo -e "  Target (dev):  ${YELLOW}${DEV_PG_USER}@${DEV_PG_HOST}/${DEV_PG_DBNAME}${NC}"
+    echo -e "  Dump file:     ${YELLOW}${DUMP_FILE}${NC}"
     echo ""
+    echo -e "${RED}⚠  This will DESTROY all data in the dev database!${NC}"
+    read -p "Proceed? (y/N) " CONFIRM
+    [[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Cancelled." && exit 0
 fi
-DEV_PG_DBNAME=${DEV_PG_DBNAME:-stacnotator}
 
-echo -e "${GREEN}✓ Dev:  ${DEV_PG_USER}@${DEV_PG_HOST}/${DEV_PG_DBNAME}${NC}"
-
-# Confirm
-
-DUMP_FILE="/tmp/stacnotator_prod_to_dev_dump.sql"
-
-echo ""
-echo -e "${BLUE}Sync Plan${NC}"
-echo -e "  Source (prod): ${YELLOW}${PROD_PG_USER}@${PROD_PG_HOST}/${PROD_PG_DBNAME}${NC}"
-echo -e "  Target (dev):  ${YELLOW}${DEV_PG_USER}@${DEV_PG_HOST}/${DEV_PG_DBNAME}${NC}"
-echo -e "  Dump file:     ${YELLOW}${DUMP_FILE}${NC}"
-echo ""
-echo -e "${RED}⚠  This will DESTROY all data in the dev database!${NC}"
-read -p "Proceed? (y/N) " CONFIRM
-[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Cancelled." && exit 0
-
-# Dump prod
+# =============================================================================
+# DUMP PROD (read-only, no writes possible with the verified user)
+# =============================================================================
 
 echo ""
 echo -e "${YELLOW}Dumping production database...${NC}"
 PGPASSWORD="$PROD_PG_PASS" pg_dump \
-    --host="$PROD_PG_HOST" \
-    --port=5432 \
-    --username="$PROD_PG_USER" \
-    --dbname="$PROD_PG_DBNAME" \
-    --no-owner \
-    --no-privileges \
-    --format=plain \
+    --host="$PROD_PG_HOST" --port=5432 \
+    --username="$PROD_PG_USER" --dbname="$PROD_PG_DBNAME" \
+    --no-owner --no-privileges --format=plain \
     > "$DUMP_FILE"
 
 DUMP_SIZE=$(du -h "$DUMP_FILE" | cut -f1)
 echo -e "${GREEN}✓ Dump complete (${DUMP_SIZE})${NC}"
 
-# Restore into dev
+# =============================================================================
+# RESTORE INTO DEV (target only - prod is untouched from here on)
+# =============================================================================
 
 echo ""
 echo -e "${YELLOW}Dropping and recreating dev database...${NC}"
-
 PGPASSWORD="$DEV_PG_PASS" psql \
-    --host="$DEV_PG_HOST" \
-    --port=5432 \
-    --username="$DEV_PG_USER" \
-    --dbname=postgres \
+    --host="$DEV_PG_HOST" --port=5432 \
+    --username="$DEV_PG_USER" --dbname=postgres \
     -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$DEV_PG_DBNAME' AND pid <> pg_backend_pid();" 2>/dev/null || true
 
 PGPASSWORD="$DEV_PG_PASS" psql \
-    --host="$DEV_PG_HOST" \
-    --port=5432 \
-    --username="$DEV_PG_USER" \
-    --dbname=postgres \
+    --host="$DEV_PG_HOST" --port=5432 \
+    --username="$DEV_PG_USER" --dbname=postgres \
     -c "DROP DATABASE IF EXISTS \"$DEV_PG_DBNAME\";"
 
 PGPASSWORD="$DEV_PG_PASS" psql \
-    --host="$DEV_PG_HOST" \
-    --port=5432 \
-    --username="$DEV_PG_USER" \
-    --dbname=postgres \
+    --host="$DEV_PG_HOST" --port=5432 \
+    --username="$DEV_PG_USER" --dbname=postgres \
     -c "CREATE DATABASE \"$DEV_PG_DBNAME\";"
 
 echo -e "${YELLOW}Restoring dump into dev database...${NC}"
 PGPASSWORD="$DEV_PG_PASS" psql \
-    --host="$DEV_PG_HOST" \
-    --port=5432 \
-    --username="$DEV_PG_USER" \
-    --dbname="$DEV_PG_DBNAME" \
+    --host="$DEV_PG_HOST" --port=5432 \
+    --username="$DEV_PG_USER" --dbname="$DEV_PG_DBNAME" \
     --set ON_ERROR_STOP=off \
     -f "$DUMP_FILE" \
     2>&1 | grep -iE "error|fatal" | grep -v "already exists" | head -10 || true
 
 echo -e "${GREEN}✓ Restore complete${NC}"
 
-# Run migrations
+# =============================================================================
+# RUN MIGRATIONS (safety net - container startup also runs alembic upgrade head)
+# =============================================================================
 
 echo ""
 echo -e "${YELLOW}Running migrations on dev...${NC}"
@@ -213,10 +257,8 @@ if az containerapp show --name "$APP_BACKEND" -g "$DEV_RG" &>/dev/null; then
         echo -e "${YELLOW}⚠ No running replica found. Migrations will run on next deploy.${NC}"
     fi
 else
-    echo -e "${YELLOW}⚠ Dev backend not deployed yet. Run: ./azure_deploy/deploy-app.sh dev${NC}"
+    echo -e "${YELLOW}⚠ Dev backend not deployed yet. Migrations will run when deploy-app.sh dev runs.${NC}"
 fi
-
-# Cleanup
 
 rm -f "$DUMP_FILE"
 

--- a/backend/src/campaigns/router.py
+++ b/backend/src/campaigns/router.py
@@ -70,8 +70,9 @@ def list_all_campaigns(
 def get_campaign(
     campaign_id: int,
     campaign: Campaign = Depends(require_campaign_access),
+    db: Session = Depends(get_db),
 ):
-    return campaign
+    return service.get_campaign_full(db, campaign_id)
 
 
 @router.post(

--- a/backend/src/campaigns/service.py
+++ b/backend/src/campaigns/service.py
@@ -36,7 +36,7 @@ from src.campaigns.schemas import (
     CampaignStatistics,
     PairwiseAgreement,
 )
-from src.imagery.models import ImageryCollection, ImagerySource, ImageryView
+from src.imagery.models import ImageryCollection, ImagerySlice, ImagerySource, ImageryView
 from src.imagery.service import create_imagery_from_editor_state, re_register_stac_collections
 from src.timeseries.models import TimeSeries
 from src.timeseries.service import _add_timeseries_entry_to_layout
@@ -162,7 +162,7 @@ def get_campaign_with_layouts(db: Session, campaign_id: int) -> Campaign:
                 selectinload(Campaign.imagery_sources).options(
                     selectinload(ImagerySource.visualizations),
                     selectinload(ImagerySource.collections).options(
-                        selectinload(ImageryCollection.slices),
+                        selectinload(ImageryCollection.slices).selectinload(ImagerySlice.tile_urls),
                         joinedload(ImageryCollection.stac_config),
                     ),
                 ),

--- a/backend/src/campaigns/service.py
+++ b/backend/src/campaigns/service.py
@@ -142,42 +142,43 @@ def list_campaigns_with_user_roles(db: Session, user_id: UUID) -> list[dict]:
     return results
 
 
-def get_campaign_with_layouts(db: Session, campaign_id: int) -> Campaign:
-    """
-    Get campaign with everything CampaignOutFull serializes eagerly loaded.
+# Eager-load options covering every relationship that CampaignOut(+Full) serializes.
+# Without these, Pydantic serialization lazy-loads each relationship one row at a
+# time - on large campaigns (thousands of slices/tile_urls) that turns a single
+# response into thousands of cross-region round-trips.
+_CAMPAIGN_FULL_LOAD_OPTIONS = (
+    joinedload(Campaign.settings),
+    selectinload(Campaign.canvas_layouts),
+    selectinload(Campaign.time_series),
+    selectinload(Campaign.basemaps),
+    selectinload(Campaign.imagery_sources).options(
+        selectinload(ImagerySource.visualizations),
+        selectinload(ImagerySource.collections).options(
+            selectinload(ImageryCollection.slices).selectinload(ImagerySlice.tile_urls),
+            joinedload(ImageryCollection.stac_config),
+        ),
+    ),
+    selectinload(Campaign.imagery_views).selectinload(ImageryView.canvas_layouts),
+)
 
-    Without the eager loads below, every relationship access during Pydantic
-    serialization triggers a separate round-trip to the DB. On a cross-region
-    deployment that adds up to hundreds of ms per annotator load.
-    """
 
+def get_campaign_full(db: Session, campaign_id: int) -> Campaign:
+    """Load a campaign with every relationship that CampaignOut serializes."""
     campaign = (
         db.execute(
-            select(Campaign)
-            .options(
-                joinedload(Campaign.settings),
-                selectinload(Campaign.canvas_layouts),
-                selectinload(Campaign.time_series),
-                selectinload(Campaign.basemaps),
-                selectinload(Campaign.imagery_sources).options(
-                    selectinload(ImagerySource.visualizations),
-                    selectinload(ImagerySource.collections).options(
-                        selectinload(ImageryCollection.slices).selectinload(ImagerySlice.tile_urls),
-                        joinedload(ImageryCollection.stac_config),
-                    ),
-                ),
-                selectinload(Campaign.imagery_views).selectinload(ImageryView.canvas_layouts),
-            )
-            .where(Campaign.id == campaign_id)
+            select(Campaign).options(*_CAMPAIGN_FULL_LOAD_OPTIONS).where(Campaign.id == campaign_id)
         )
         .unique()
         .scalar_one_or_none()
     )
-
     if not campaign:
         raise HTTPException(status_code=404, detail="Campaign not found")
-
     return campaign
+
+
+def get_campaign_with_layouts(db: Session, campaign_id: int) -> Campaign:
+    """Alias for get_campaign_full - used by the /detailed endpoint."""
+    return get_campaign_full(db, campaign_id)
 
 
 def create_campaign(
@@ -380,7 +381,7 @@ def create_campaign(
 
         threading.Thread(target=_background_register_embeddings, daemon=True).start()
 
-    return campaign
+    return get_campaign_full(db, campaign.id)
 
 
 def add_users_to_campaign_bulk(
@@ -464,7 +465,7 @@ def update_campaign_name(db: Session, campaign_id: int, new_name: str) -> Campai
         raise HTTPException(status_code=404, detail="Campaign not found")
     campaign.name = new_name
     db.commit()
-    return campaign
+    return get_campaign_full(db, campaign_id)
 
 
 def update_campaign_visibility(db: Session, campaign_id: int, is_public: bool) -> Campaign:
@@ -474,7 +475,7 @@ def update_campaign_visibility(db: Session, campaign_id: int, is_public: bool) -
         raise HTTPException(status_code=404, detail="Campaign not found")
     campaign.is_public = is_public
     db.commit()
-    return campaign
+    return get_campaign_full(db, campaign_id)
 
 
 def update_campaign_guide(db: Session, campaign_id: int, guide_markdown: str | None) -> Campaign:
@@ -485,7 +486,7 @@ def update_campaign_guide(db: Session, campaign_id: int, guide_markdown: str | N
         raise HTTPException(status_code=404, detail="Campaign settings not found")
     campaign.settings.guide_markdown = guide_markdown
     db.commit()
-    return campaign
+    return get_campaign_full(db, campaign_id)
 
 
 def update_campaign_bbox(db: Session, campaign_id: int, bbox: dict) -> Campaign:
@@ -517,7 +518,7 @@ def update_campaign_bbox(db: Session, campaign_id: int, bbox: dict) -> Campaign:
         )
 
     db.commit()
-    return campaign
+    return get_campaign_full(db, campaign_id)
 
 
 def update_sample_extent(
@@ -530,7 +531,7 @@ def update_sample_extent(
         raise HTTPException(status_code=404, detail="Campaign settings not found")
     campaign.settings.sample_extent_meters = sample_extent_meters
     db.commit()
-    return campaign
+    return get_campaign_full(db, campaign_id)
 
 
 def update_embedding_year(


### PR DESCRIPTION
This pull request introduces the CI workflow for deploying to dev on azure. Also improving lazy loading for campaigns that resulted in individual DB queries having a huge overhead - optimized into single query.

**Dev deployment workflow and automation:**

* Added a new `.github/workflows/deploy-dev.yml` workflow for manual-only deployments to the dev Azure environment. This workflow allows safe, on-demand dev deployments (including optional syncing of prod data) and is designed to prevent accidental or automated writes to production.
* Updated `.github/workflows/ci.yml` to restrict certain jobs (secret scanning, linting, tests, and Docker builds) from running on pull requests targeting `develop` or `main`, reducing unnecessary CI runs and potential exposure of secrets. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR21) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR35) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR62) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL90-R97) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL176-R182)

**Production data sync safety and script improvements:**

* Enhanced `azure_deploy/sync-prod-data-to-dev.sh` with strict safety guards: the script now aborts if the source and target hosts, databases, or resource groups match, or if the target host doesn't look like a dev server. It also clearly separates interactive (human) and CI (automated) modes, ensuring credentials are handled appropriately in each case. [[1]](diffhunk://#diff-ebc90cc41f39802d6a2788cce0c9d6bc8efde1aaa7f8fdd764b4d5f0ea9987a6L6-R31) [[2]](diffhunk://#diff-ebc90cc41f39802d6a2788cce0c9d6bc8efde1aaa7f8fdd764b4d5f0ea9987a6R44-R154)

**Documentation updates:**

* Expanded `azure_deploy/README.md` with detailed instructions for the new dev deployment workflow, including one-time setup steps for mirroring prod DB credentials into the dev Key Vault, configuring GitHub secrets, and enabling safe, manual CI-based dev deployments. Minor clarifications and consistency fixes were also made throughout the documentation. [[1]](diffhunk://#diff-73664fa352ebcc98d5b148551f16b4a8a1f5dd7219a17160b43417ed3419a8c4L19-R19) [[2]](diffhunk://#diff-73664fa352ebcc98d5b148551f16b4a8a1f5dd7219a17160b43417ed3419a8c4L41-R41) [[3]](diffhunk://#diff-73664fa352ebcc98d5b148551f16b4a8a1f5dd7219a17160b43417ed3419a8c4L80-R80) [[4]](diffhunk://#diff-73664fa352ebcc98d5b148551f16b4a8a1f5dd7219a17160b43417ed3419a8c4L92-R92) [[5]](diffhunk://#diff-73664fa352ebcc98d5b148551f16b4a8a1f5dd7219a17160b43417ed3419a8c4R108-R158)