### PR TITLE
Fix: Collection order & timeseries reloading

### DIFF
--- a/frontend/src/features/annotation/components/Canvas.tsx
+++ b/frontend/src/features/annotation/components/Canvas.tsx
@@ -236,66 +236,46 @@ export const Canvas = ({ commentInputRef }: CanvasProps) => {
     );
   }, [activeSource, campaign, selectedLayerIndex]);
 
-  // Open mode: viewport center. Task mode: task geometry centroid.
-  const latLon = useMemo<LatLon | null>(() => {
+  // Own memo (geometry-only deps) so its reference stays stable across pans.
+  const taskCentroid = useMemo<LatLon | null>(
+    () => (currentTask ? extractCentroidFromWKT(currentTask.geometry.geometry) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentTask?.geometry.geometry]
+  );
+
+  // Open mode: map center. Task mode: the (stable) task centroid.
+  const focusPoint = useMemo<LatLon | null>(() => {
     if (isOpenMode) {
       if (currentMapCenter) return { lat: currentMapCenter[0], lon: currentMapCenter[1] };
       return null;
     }
-    return currentTask ? extractCentroidFromWKT(currentTask.geometry.geometry) : null;
+    return taskCentroid;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpenMode, currentMapCenter?.[0], currentMapCenter?.[1], currentTask?.geometry.geometry]);
+  }, [isOpenMode, currentMapCenter?.[0], currentMapCenter?.[1], taskCentroid]);
 
   // Open mode only sends a timeseries point when explicitly clicked with the
   // timeseries tool; task mode always uses the task centroid.
   const timeseriesLatLon = useMemo<LatLon | null>(() => {
     if (isOpenMode) return timeseriesPoint;
-    return latLon;
-  }, [isOpenMode, timeseriesPoint, latLon]);
+    return focusPoint;
+  }, [isOpenMode, timeseriesPoint, focusPoint]);
 
   const center = useMemo<[number, number]>(
-    () => (latLon ? [latLon.lat, latLon.lon] : [0, 0]),
+    () => (focusPoint ? [focusPoint.lat, focusPoint.lon] : [0, 0]),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [latLon?.lat, latLon?.lon]
+    [focusPoint?.lat, focusPoint?.lon]
   );
 
   if (!campaign) return null;
 
   const renderMainHeader = () => {
-    const taskStatus = currentTask?.task_status as
-      | 'pending'
-      | 'partial'
-      | 'done'
-      | 'conflicting'
-      | 'skipped'
-      | undefined;
-    const statusDotColor: Record<NonNullable<typeof taskStatus>, string> = {
-      pending: 'bg-neutral-300',
-      partial: 'bg-amber-500',
-      done: 'bg-brand-600',
-      conflicting: 'bg-orange-500',
-      skipped: 'bg-violet-500',
-    };
-
     return (
       <div className="flex items-center justify-between gap-3 w-full">
         <div className="flex items-center gap-2 min-w-0 shrink-0">
           {!isOpenMode && currentTask ? (
-            <>
-              {taskStatus && (
-                <span
-                  className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusDotColor[taskStatus]}`}
-                  title={taskStatus}
-                  aria-hidden
-                />
-              )}
-              <span className="hidden desktop:inline text-[11px] font-medium text-neutral-500 uppercase tracking-wider">
-                Point
-              </span>
-              <span className="hidden desktop:inline text-xs font-semibold text-neutral-900 tabular-nums">
-                {currentTask.annotation_number}
-              </span>
-            </>
+            <span className="-ml-2.5 w-[60px] shrink-0 text-center text-xs font-semibold text-neutral-900 tabular-nums">
+              {currentTask.annotation_number}
+            </span>
           ) : (
             <span className="text-xs font-medium text-neutral-700 truncate">
               {showBasemap
@@ -340,14 +320,14 @@ export const Canvas = ({ commentInputRef }: CanvasProps) => {
       <span className="text-[11px] font-medium text-neutral-500 uppercase tracking-wider shrink-0">
         Loc
       </span>
-      {latLon ? (
+      {focusPoint ? (
         <>
           <span className="tabular-nums text-xs text-neutral-700 font-medium truncate">
-            {latLon.lat.toFixed(5)}, {latLon.lon.toFixed(5)}
+            {focusPoint.lat.toFixed(5)}, {focusPoint.lon.toFixed(5)}
           </span>
           <div className="flex items-center gap-0.5 ml-auto shrink-0">
             <button
-              onClick={() => copyToClipboard(`${latLon.lat},${latLon.lon}`)}
+              onClick={() => copyToClipboard(`${focusPoint.lat},${focusPoint.lon}`)}
               className="p-1 text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 rounded transition-colors"
               title="Copy coordinates to clipboard"
             >
@@ -357,7 +337,7 @@ export const Canvas = ({ commentInputRef }: CanvasProps) => {
               </svg>
             </button>
             <a
-              href={`https://earth.google.com/web/search/${latLon.lat},${latLon.lon}`}
+              href={`https://earth.google.com/web/search/${focusPoint.lat},${focusPoint.lon}`}
               target="_blank"
               rel="noopener noreferrer"
               className="p-1 text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100 rounded transition-colors"

--- a/frontend/src/features/annotation/components/Canvas.tsx
+++ b/frontend/src/features/annotation/components/Canvas.tsx
@@ -18,6 +18,7 @@ import { useLayoutStore } from '~/features/layout/layout.store';
 import { useContainerWidth } from '../hooks/useContainerWidth';
 import { handleError } from '~/shared/utils/errorHandler';
 import { useIsMobile } from '~/shared/utils/useIsMobile';
+import { byCollectionDate } from '../utils/collectionOrder';
 import { HiddenWindowsPanel } from './HiddenWindowsPanel';
 import { WindowDropController } from './WindowDropController';
 import { IconEyeSlash } from '~/shared/ui/Icons';
@@ -156,7 +157,8 @@ export const Canvas = ({ commentInputRef }: CanvasProps) => {
         const collection = source?.collections.find((c) => c.id === ref.collection_id);
         return { ...ref, collection, source };
       })
-      .filter((r) => r.collection && r.source);
+      .filter((r) => r.collection && r.source)
+      .sort(byCollectionDate);
   }, [campaign, selectedView, currentLayout]);
 
   // On mobile we ignore the saved desktop layout and stack everything in a

--- a/frontend/src/features/annotation/components/TimeSeries/TimeSeriesChart.tsx
+++ b/frontend/src/features/annotation/components/TimeSeries/TimeSeriesChart.tsx
@@ -141,7 +141,8 @@ export const TimeSeriesChart = ({
     return () => {
       cancelled = true;
     };
-  }, [timeseriesIds, latLon]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-fetch when lat/lon change
+  }, [timeseriesIds, latLon?.lat, latLon?.lon]);
 
   // Prefetch upcoming coordinates
   useEffect(() => {

--- a/frontend/src/features/annotation/components/TimelineSidebar.tsx
+++ b/frontend/src/features/annotation/components/TimelineSidebar.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useCallback, useMemo, useEffect } from 'react';
 import type { CampaignOutFull } from '~/api/client';
 import { sliceView } from '../utils/sliceView';
+import { byCollectionDate } from '../utils/collectionOrder';
 
 interface TimelineSidebarProps {
   campaign: CampaignOutFull;
@@ -72,7 +73,8 @@ const TimelineSidebar = ({
         const collection = source?.collections.find((c) => c.id === ref.collection_id);
         return { ...ref, collection, source };
       })
-      .filter((r) => r.collection);
+      .filter((r) => r.collection)
+      .sort(byCollectionDate);
   }, [selectedView, campaign.imagery_sources, activeSourceId]);
 
   const dateRange = useMemo(() => {

--- a/frontend/src/features/annotation/hooks/useSliceNavigation.ts
+++ b/frontend/src/features/annotation/hooks/useSliceNavigation.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useCampaignStore } from '../stores/campaign.store';
 import { useMapStore } from '../stores/map.store';
 import { sliceView } from '../utils/sliceView';
+import { byCollectionDate } from '../utils/collectionOrder';
 
 /**
  * Shared slice/collection navigation used by keyboard shortcuts and on-screen
@@ -38,7 +39,7 @@ export const useSliceNavigation = () => {
       id: number;
       cover_slice_index: number;
       has_dedicated_cover?: boolean;
-      slices: { name: string }[];
+      slices: { name: string; start_date: string }[];
     };
   };
 
@@ -54,7 +55,8 @@ export const useSliceNavigation = () => {
         if (!source || !collection) return null;
         return { ...ref, collection, source } as ViewCollection;
       })
-      .filter((c): c is ViewCollection => c !== null);
+      .filter((c): c is ViewCollection => c !== null)
+      .sort(byCollectionDate);
   }, [selectedView, campaign, activeSourceId]);
 
   const currentCollectionIndex = viewCollections.findIndex(

--- a/frontend/src/features/annotation/utils/collectionOrder.test.ts
+++ b/frontend/src/features/annotation/utils/collectionOrder.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { collectionStartDate, byCollectionDate } from './collectionOrder';
+
+const col = (...starts: string[]) => ({
+  slices: starts.map((start_date) => ({ start_date })),
+});
+
+describe('collectionStartDate', () => {
+  it('returns the earliest slice start date', () => {
+    expect(collectionStartDate(col('2020-06-01', '2020-01-01', '2020-09-01'))).toBe('2020-01-01');
+  });
+
+  it('ignores empty slice dates when picking the earliest', () => {
+    expect(collectionStartDate(col('', '2019-03-01', ''))).toBe('2019-03-01');
+  });
+
+  it('sorts collections with no usable date last', () => {
+    expect(collectionStartDate(col())).toBe('9999-99-99');
+    expect(collectionStartDate(col('', ''))).toBe('9999-99-99');
+  });
+});
+
+describe('byCollectionDate', () => {
+  const entry = (id: number, ...starts: string[]) => ({ id, collection: col(...starts) });
+
+  it('orders a later-added but earlier-dated collection ahead (the 2019-after-2020 case)', () => {
+    // 2020 collection was added first, 2019 added afterwards.
+    const items = [entry(1, '2020-01-01'), entry(2, '2019-01-01')];
+    const ordered = [...items].sort(byCollectionDate).map((e) => e.id);
+    expect(ordered).toEqual([2, 1]);
+  });
+
+  it('orders by earliest slice across multiple collections', () => {
+    const items = [
+      entry(1, '2021-05-01'),
+      entry(2, '2019-07-01', '2019-01-01'),
+      entry(3, '2020-02-01'),
+    ];
+    expect([...items].sort(byCollectionDate).map((e) => e.id)).toEqual([2, 3, 1]);
+  });
+
+  it('keeps undated collections at the end', () => {
+    const items = [entry(1), entry(2, '2020-01-01'), entry(3, '2018-01-01')];
+    expect([...items].sort(byCollectionDate).map((e) => e.id)).toEqual([3, 2, 1]);
+  });
+
+  it('is stable for equal dates (preserves insertion order)', () => {
+    const items = [entry(1, '2020-01-01'), entry(2, '2020-01-01'), entry(3, '2020-01-01')];
+    expect([...items].sort(byCollectionDate).map((e) => e.id)).toEqual([1, 2, 3]);
+  });
+
+  it('treats a null/missing collection as undated (sorts last)', () => {
+    const items = [{ id: 1, collection: null }, entry(2, '2020-01-01')];
+    expect([...items].sort(byCollectionDate).map((e) => e.id)).toEqual([2, 1]);
+  });
+});

--- a/frontend/src/features/annotation/utils/collectionOrder.ts
+++ b/frontend/src/features/annotation/utils/collectionOrder.ts
@@ -1,0 +1,29 @@
+/** Chronological ordering for a source's collections in the timeline.
+ *
+ * Collections are stored/referenced in insertion order, so a collection added
+ * later but covering an earlier period (e.g. 2019 imagery added after 2020)
+ * would otherwise show up at the end of the timeline. Ordering by the earliest
+ * slice start date slots it into its proper place. */
+
+interface DatedCollection {
+  slices: { start_date: string }[];
+}
+
+/** Earliest slice start date (YYYY-MM-DD). Empty/undated collections sort last. */
+export function collectionStartDate(collection: DatedCollection): string {
+  let earliest = '';
+  for (const s of collection.slices) {
+    if (s.start_date && (!earliest || s.start_date < earliest)) earliest = s.start_date;
+  }
+  return earliest || '9999-99-99';
+}
+
+/** Stable chronological comparator for entries carrying a `collection`. */
+export function byCollectionDate<T extends { collection?: DatedCollection | null }>(
+  a: T,
+  b: T
+): number {
+  const da = a.collection ? collectionStartDate(a.collection) : '9999-99-99';
+  const db = b.collection ? collectionStartDate(b.collection) : '9999-99-99';
+  return da.localeCompare(db);
+}


### PR DESCRIPTION
**Summary**

- Ensuring collections are ordered by date for meaningful navigation
- Avoiding object reconstruction for lat/lon on map movement, to avoid timeseries race conditon due to changed dependancy