### PR TITLE
fix(router): friendly 404 + error boundary

### DIFF
--- a/frontend/src/app/RouteError.tsx
+++ b/frontend/src/app/RouteError.tsx
@@ -1,0 +1,73 @@
+import { Link, useRouteError, isRouteErrorResponse } from 'react-router-dom';
+
+/** Shared centred content for the 404 / error screens. */
+function ErrorContent({ code, title, message }: { code: string; title: string; message: string }) {
+  return (
+    <div className="mx-auto max-w-xl px-8 py-24 text-center">
+      <p className="text-6xl font-semibold tracking-tight text-neutral-300 tabular-nums">{code}</p>
+      <h1 className="mt-4 text-xl font-semibold text-neutral-900">{title}</h1>
+      <p className="mt-2 text-[15px] leading-relaxed text-neutral-600">{message}</p>
+      <div className="mt-8 flex items-center justify-center gap-3">
+        <Link
+          to="/"
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-700"
+        >
+          Go to home
+        </Link>
+        <button
+          onClick={() => window.location.reload()}
+          className="rounded-md border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100"
+        >
+          Reload
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Catch-all route element: renders inside AppLayout so the sidebar stays. */
+export function NotFoundPage() {
+  return (
+    <div className="flex-1 overflow-auto">
+      <ErrorContent
+        code="404"
+        title="Page not found"
+        message="The page you're looking for doesn't exist or may have moved."
+      />
+    </div>
+  );
+}
+
+/**
+ * Route `errorElement`: replaces the layout when a route (or loader) throws.
+ * A thrown 404 still shows the not-found copy; anything else gets a generic
+ * recoverable error screen instead of React Router's developer default.
+ */
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <div className="flex min-h-[100dvh] items-center justify-center bg-white">
+        <ErrorContent
+          code="404"
+          title="Page not found"
+          message="The page you're looking for doesn't exist or may have moved."
+        />
+      </div>
+    );
+  }
+
+  const code = isRouteErrorResponse(error) ? String(error.status) : 'Error';
+  const message = isRouteErrorResponse(error)
+    ? error.statusText || 'Something went wrong while loading this page.'
+    : error instanceof Error
+      ? error.message
+      : 'An unexpected error occurred. Try reloading the page.';
+
+  return (
+    <div className="flex min-h-[100dvh] items-center justify-center bg-white">
+      <ErrorContent code={code} title="Something went wrong" message={message} />
+    </div>
+  );
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -8,6 +8,7 @@ import {
 import { CampaignsPage } from 'src/features/campaigns/pages/CampaignsOverviewPage';
 import { HomePage } from 'src/features/home/pages/HomePage';
 import { AppLayout } from '~/features/layout/components/AppLayout';
+import { NotFoundPage, RouteErrorBoundary } from './RouteError';
 
 // Heavy routes are code-split so the initial bundle (Home + Campaigns list)
 // doesn't include OpenLayers, Chart.js, react-markdown, etc.
@@ -46,7 +47,7 @@ const RouteFallback = () => (
 // can be intercepted via useBlocker - see useUnsavedChangesGuard.
 const router = createBrowserRouter(
   createRoutesFromElements(
-    <Route path="/" element={<AppLayout />}>
+    <Route path="/" element={<AppLayout />} errorElement={<RouteErrorBoundary />}>
       <Route index element={<HomePage />} />
       <Route path="campaigns" element={<CampaignsPage />} />
       <Route
@@ -89,6 +90,8 @@ const router = createBrowserRouter(
           </Suspense>
         }
       />
+      {/* Unmatched paths render a friendly 404 within the layout. */}
+      <Route path="*" element={<NotFoundPage />} />
     </Route>
   )
 );


### PR DESCRIPTION
## Problem

Navigating to a path that doesn't exist showed React Router's **developer default** page:

> Unexpected Application Error! · 404 Not Found · 💿 Hey developer 👋 … provide your own ErrorBoundary or errorElement …

The data router (`createBrowserRouter`) had no `errorElement` and no catch-all route.

## Fix

- **Catch-all `*` route** inside `AppLayout` → renders a friendly **404 page within the layout** (sidebar + header stay), with **Go to home** / **Reload** actions. This covers the reported case (bad URL).
- **`errorElement` on the root route** (`RouteErrorBoundary`) → any thrown route/loader error now gets a recoverable error screen (a thrown 404 still shows the not-found copy) instead of the dev default.
- New `src/app/RouteError.tsx` holding `NotFoundPage` + `RouteErrorBoundary`, styled with the app's existing neutral/brand Tailwind tokens.

## Verification

Ran the app and navigated to `/this-page-does-not-exist`: renders the 404 within the layout, no dev default error (screenshot confirmed). `tsc`, eslint, prettier all pass.
