### PR TITLE
fix: annotation tile serving resilient under concurrent load

### DIFF
--- a/backend/src/annotation/service.py
+++ b/backend/src/annotation/service.py
@@ -28,6 +28,7 @@ from src.annotation.tiles import build_mvt_query
 from src.auth.service import is_admin as is_platform_admin
 from src.campaigns.models import Campaign, CampaignUser
 from src.campaigns.service import is_authoritative_reviewer
+from src.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -638,8 +639,12 @@ def render_annotation_tile(
     """Render one MVT tile of a campaign's annotations as protobuf bytes.
 
     Returns an empty tile (zero-length bytes) when no geometry falls in the
-    tile, which OpenLayers treats as an empty tile.
+    tile, which OpenLayers treats as an empty tile. Zoom levels below
+    ``ANNOTATION_TILE_MIN_ZOOM`` also return empty without touching the DB, so a
+    whole-country view of dense parcels can't trigger a multi-MB, CPU-heavy query.
     """
+    if z < get_settings().ANNOTATION_TILE_MIN_ZOOM:
+        return b""
     sql, params = build_mvt_query(z=z, x=x, y=y, campaign_id=campaign_id)
     tile = db.execute(text(sql), params).scalar_one()
     return bytes(tile) if tile is not None else b""

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -40,6 +40,23 @@ class Settings(BaseSettings):
     # the Postgres server's max_connections. Lower these on small DB SKUs.
     DB_POOL_SIZE: int = 15
     DB_MAX_OVERFLOW: int = 20
+    # Fail a request fast if no pooled connection frees up in this many seconds,
+    # instead of hanging (and piling up) when the DB is saturated.
+    DB_POOL_TIMEOUT: int = 10
+    # Postgres reaps a connection left idle-in-transaction this long (ms), so a
+    # leaked session self-heals back into the pool instead of wedging it forever.
+    DB_IDLE_IN_TRANSACTION_TIMEOUT_MS: int = 15000
+
+    # AnyIO threadpool size for sync routes. Must exceed (DB_POOL_SIZE +
+    # DB_MAX_OVERFLOW) so a sync `get_db` dependency's cleanup is never starved of a
+    # thread under load (which leaks the connection). The DB pool — not this — stays
+    # the hard cap on concurrent DB work, keeping small/burstable DBs safe.
+    THREAD_POOL_MAX: int = 96
+
+    # Below this zoom the annotation MVT endpoint returns an empty tile instead of
+    # encoding thousands of features (a whole-country view of dense parcels is a
+    # multi-MB, multi-hundred-ms query). Keeps low-zoom panning cheap and bounded.
+    ANNOTATION_TILE_MIN_ZOOM: int = 11
 
     ENVIRONMENT: str = "development"  # "development" | "production"
 

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -26,8 +26,13 @@ engine = create_engine(
     max_overflow=settings.DB_MAX_OVERFLOW,
     pool_recycle=240,
     pool_pre_ping=True,
+    pool_timeout=settings.DB_POOL_TIMEOUT,
     connect_args={
         "application_name": "stacnotator-backend",
+        # Postgres-side backstop: reap a session left idle-in-transaction (e.g. a
+        # dependency whose cleanup was skipped under load) so the pooled connection
+        # returns to service instead of wedging the pool permanently.
+        "options": f"-c idle_in_transaction_session_timeout={settings.DB_IDLE_IN_TRANSACTION_TIMEOUT_MS}",
         "keepalives": 1,
         "keepalives_idle": 30,
         "keepalives_interval": 10,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -61,6 +61,12 @@ def _validate_production_config() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _validate_production_config()
+    # Sync routes and their sync `get_db` cleanup share this pool; if it saturates,
+    # cleanup is starved and connections leak. Size it above the DB pool so cleanup
+    # always has a thread. DB concurrency stays capped by the (small) DB pool.
+    from anyio import to_thread
+
+    to_thread.current_default_thread_limiter().total_tokens = settings.THREAD_POOL_MAX
     initialize_earth_engine()
     yield
 

--- a/frontend/src/features/annotation/components/Map/useAnnotationTileLayer.ts
+++ b/frontend/src/features/annotation/components/Map/useAnnotationTileLayer.ts
@@ -43,6 +43,12 @@ const TILE_PROP_LABEL = 'label_id';
 const HIGHLIGHT_Z_INDEX = ANNOTATION_LAYER_Z_INDEX + 1;
 const apiBase = import.meta.env.VITE_API_BASE_URL ?? '';
 
+// Don't request annotation tiles when zoomed out: a whole-region view of dense
+// campaigns is a multi-MB, CPU-heavy MVT query. The backend also floors this
+// (ANNOTATION_TILE_MIN_ZOOM), so the layer is hidden below it either way; this just
+// avoids firing empty requests. OL's `minZoom` is exclusive, hence the -1.
+const ANNOTATION_TILE_MIN_ZOOM = 11;
+
 /** Resolve each campaign label to the paint the tiles use, honouring overrides. */
 function resolveTileLabelStyles(
   campaign: CampaignOutFull,
@@ -127,6 +133,7 @@ export function createAnnotationDisplayLayer(
   const layer = new VectorTileLayer({
     source: createAnnotationTileSource(campaign.id, getVersion),
     zIndex: ANNOTATION_LAYER_Z_INDEX,
+    minZoom: ANNOTATION_TILE_MIN_ZOOM - 1,
     // Re-render during zoom/pan so strokes stay crisp instead of the prior
     // zoom level's tiles being scaled up (which makes polygons "pulse").
     updateWhileAnimating: true,


### PR DESCRIPTION
**Summary**
Load-testing the annotation vector-tile serving (a dense US-parcel campaign, ~50k polygons, multiple users panning) uncovered a systemic availability bug: under concurrent load the backend leaks its whole DB connection pool and **wedges permanently — until restart** — affecting every endpoint, not just tiles.

Root cause: sync routes and their sync `get_db` yield-cleanup share Starlette's AnyIO threadpool (default 40). When ~40+ requests run concurrently the pool saturates, the `db.close()` cleanup is starved, and sessions leak as `idle in transaction` until the 35-connection DB pool is exhausted and nothing can get a connection. Measured: 40+ concurrent users wedge the server every time; ≤36 is fine. Reproduced on the cheap `/api/campaigns/` endpoint too, so it is not tile-specific — the tiles just make the concurrency trivial to reach.

The fix is deliberately safe for the **burstable Azure Postgres tier** (limited connections + CPU credits): it does **not** enlarge the DB pool (that would just dogpile the DB). The small pool stays the hard cap on DB concurrency; excess load fails fast.

**Changes**
- Raise the AnyIO threadpool above the DB pool (`THREAD_POOL_MAX`) so `get_db` cleanup is never starved — the actual leak fix.
- `pool_timeout` (fail fast instead of hanging) + `idle_in_transaction_session_timeout` (Postgres reaps a leaked session so the pool self-heals instead of wedging).
- Annotation MVT endpoint returns an empty tile below `ANNOTATION_TILE_MIN_ZOOM` (and the OpenLayers layer stops requesting there), so a whole-country view of dense parcels can't trigger a multi-MB / ~300 ms query.

**Validated** (same 40–100 concurrent-user load that previously wedged the server every time)
- 0 connections leaked; backend self-recovers and stays responsive (~15 ms) instead of dying until restart.
- z8 tile: 322 ms / 1.5 MB → 8 ms / 0 B.

**Azure note:** keep `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` sized so `(pool × workers) + the tiler's pool` stays under the burstable server's `max_connections`.
