### PR TITLE
fix stac catalogs 500 (stacindex numeric id)

### DIFF
--- a/backend/src/tiling/router.py
+++ b/backend/src/tiling/router.py
@@ -145,6 +145,31 @@ def _tiler_catalogs(user: User) -> list[dict]:
     return out
 
 
+def _map_stacindex_catalog(cat: dict) -> dict | None:
+    """Map one raw StacIndex catalog to our output shape, or None to skip it.
+
+    Skips non-API catalogs and the Planetary Computer (added explicitly as MPC).
+    Uses the stable string `slug` as the id: StacIndex's `id` is a numeric,
+    unstable value, and `_AUTH_REQUIRED_CATALOGS` matches on the slug.
+    """
+    if not cat.get("isApi"):
+        return None
+    url = cat.get("url", "")
+    if "planetarycomputer" in url:
+        return None
+    cat_id = cat.get("slug") or str(cat.get("id", ""))
+    return {
+        "id": cat_id,
+        "title": cat.get("title", ""),
+        "url": url,
+        "summary": cat.get("summary", ""),
+        "is_mpc": False,
+        "auth_required": cat_id in _AUTH_REQUIRED_CATALOGS,
+        "tiler_name": None,
+        "provided": False,
+    }
+
+
 async def _public_catalogs() -> list[dict]:
     """MPC + StacIndex API catalogs (user-independent), cached. Proxied via StacIndex."""
     now = time.time()
@@ -177,24 +202,9 @@ async def _public_catalogs() -> list[dict]:
     )
 
     for cat in all_catalogs:
-        if not cat.get("isApi"):
-            continue
-        url = cat.get("url", "")
-        if "planetarycomputer" in url:
-            continue
-        cat_id = cat.get("id") or cat.get("slug", "")
-        filtered.append(
-            {
-                "id": cat_id,
-                "title": cat.get("title", ""),
-                "url": url,
-                "summary": cat.get("summary", ""),
-                "is_mpc": False,
-                "auth_required": cat_id in _AUTH_REQUIRED_CATALOGS,
-                "tiler_name": None,
-                "provided": False,
-            }
-        )
+        mapped = _map_stacindex_catalog(cat)
+        if mapped is not None:
+            filtered.append(mapped)
 
     _catalogs_cache["data"] = filtered
     _catalogs_cache["expires"] = now + STACINDEX_CACHE_TTL

--- a/backend/tests/unit/test_stacindex_catalog_mapping.py
+++ b/backend/tests/unit/test_stacindex_catalog_mapping.py
@@ -1,0 +1,44 @@
+from src.tiling.router import _map_stacindex_catalog
+
+
+def test_uses_slug_as_id_not_numeric_id():
+    # StacIndex now returns a numeric `id`; the output id must be the string slug.
+    out = _map_stacindex_catalog(
+        {
+            "isApi": True,
+            "id": 16,
+            "slug": "astraea-earth-ondemand",
+            "title": "Astraea",
+            "url": "https://a",
+        }
+    )
+    assert out is not None
+    assert out["id"] == "astraea-earth-ondemand"
+    assert isinstance(out["id"], str)
+
+
+def test_auth_required_matches_on_slug():
+    out = _map_stacindex_catalog(
+        {"isApi": True, "id": 99, "slug": "maxar", "title": "Maxar", "url": "https://m"}
+    )
+    assert out is not None
+    assert out["auth_required"] is True
+
+
+def test_falls_back_to_stringified_id_when_no_slug():
+    out = _map_stacindex_catalog({"isApi": True, "id": 42, "title": "x", "url": "https://x"})
+    assert out is not None
+    assert out["id"] == "42"
+
+
+def test_skips_non_api_catalogs():
+    assert _map_stacindex_catalog({"isApi": False, "slug": "static-thing"}) is None
+
+
+def test_skips_planetary_computer():
+    assert (
+        _map_stacindex_catalog(
+            {"isApi": True, "slug": "mpc", "url": "https://planetarycomputer.microsoft.com/api"}
+        )
+        is None
+    )


### PR DESCRIPTION
GET /api/stac/catalogs was 500ing (ResponseValidationError, 57 errors).

stacindex started returning a numeric `id` on its catalogs (e.g. 16, 112), but StacCatalogOut.id is a str, so response validation blew up. it also silently broke the auth_required check, which matches on strings like "usgs-m2m" / "maxar".

fix: use the stable string `slug` as the catalog id instead of the numeric `id` (fall back to str(id) if no slug). slug is what _AUTH_REQUIRED_CATALOGS matches on anyway.

pulled the per-catalog mapping out into a pure helper (_map_stacindex_catalog) with unit tests: slug as id, numeric-id fallback, auth match on slug, skip non-api, skip planetary computer.

checked against the live stacindex response: all 57 api catalogs now map and validate through StacCatalogOut, all ids are strings.

pre-existing bug, not related to any feature work, hit it while adding imagery in the campaign editor.
