### PR TITLE
feat: clearer imagery temporal presets, NAIP yearly default

### DIFF
--- a/frontend/src/features/campaigns/components/imagery/CatalogBrowser.tsx
+++ b/frontend/src/features/campaigns/components/imagery/CatalogBrowser.tsx
@@ -25,11 +25,75 @@ import { extractErrorMessage, handleError } from '~/shared/utils/errorHandler';
 
 type Step = 'catalog' | 'collection' | 'configure';
 
+type TemporalPattern =
+  | 'monthly-weekly'
+  | 'monthly-monthly'
+  | 'weekly-weekly'
+  | 'yearly-monthly'
+  | 'yearly-yearly'
+  | 'custom';
+
+interface TemporalPatternOption {
+  id: Exclude<TemporalPattern, 'custom'>;
+  label: string;
+  windowInterval: number;
+  windowUnit: 'weeks' | 'months' | 'years';
+  sliceInterval: number;
+  sliceUnit: 'days' | 'weeks' | 'months' | 'years';
+}
+
+const TEMPORAL_PATTERNS: TemporalPatternOption[] = [
+  {
+    id: 'monthly-weekly',
+    label: 'Month by month, with weekly images to choose from',
+    windowInterval: 1,
+    windowUnit: 'months',
+    sliceInterval: 1,
+    sliceUnit: 'weeks',
+  },
+  {
+    id: 'monthly-monthly',
+    label: 'Month by month, one image per month',
+    windowInterval: 1,
+    windowUnit: 'months',
+    sliceInterval: 1,
+    sliceUnit: 'months',
+  },
+  {
+    id: 'weekly-weekly',
+    label: 'Week by week, one image per week',
+    windowInterval: 1,
+    windowUnit: 'weeks',
+    sliceInterval: 1,
+    sliceUnit: 'weeks',
+  },
+  {
+    id: 'yearly-monthly',
+    label: 'Year by year, with monthly images to choose from',
+    windowInterval: 1,
+    windowUnit: 'years',
+    sliceInterval: 1,
+    sliceUnit: 'months',
+  },
+  {
+    id: 'yearly-yearly',
+    label: 'Year by year, one image per year',
+    windowInterval: 1,
+    windowUnit: 'years',
+    sliceInterval: 1,
+    sliceUnit: 'years',
+  },
+];
+
 export interface CatalogBrowserPreset {
   /** STAC collection ID within MPC (e.g. 'sentinel-2-l2a') */
   stacCollectionId: string;
   /** Human label */
   label: string;
+  /** Temporal pattern to preselect; falls back to the form defaults (monthly/weekly) */
+  temporalPattern?: Exclude<TemporalPattern, 'custom'>;
+  /** Cover to preselect; falls back to a generated cover for cloud-bearing collections */
+  coverMode?: 'nth' | 'custom';
 }
 
 /** Presets that map directly to MPC STAC collections */
@@ -38,7 +102,9 @@ export const MPC_PRESETS: CatalogBrowserPreset[] = [
   { stacCollectionId: 'landsat-c2-l2', label: 'Landsat C2 L2' },
   { stacCollectionId: 'hls2-s30', label: 'HLS Sentinel-2 (S30)' },
   { stacCollectionId: 'hls2-l30', label: 'HLS Landsat (L30)' },
-  { stacCollectionId: 'naip', label: 'NAIP' },
+  // NAIP flies each state roughly every 2-3 years and carries no cloud metadata, so
+  // sub-yearly windows produce empty slices and a composited cover buys nothing.
+  { stacCollectionId: 'naip', label: 'NAIP', temporalPattern: 'yearly-yearly', coverMode: 'nth' },
   { stacCollectionId: 'sentinel-1-grd', label: 'Sentinel-1 GRD' },
   { stacCollectionId: 'cop-dem-glo-30', label: 'Copernicus DEM 30m' },
 ];
@@ -59,57 +125,6 @@ interface CatalogBrowserProps {
    *  (post-creation edits are intentional power-user actions). */
   initialAdvanced?: boolean;
 }
-
-type TemporalPattern =
-  | 'monthly-weekly'
-  | 'monthly-monthly'
-  | 'weekly-weekly'
-  | 'yearly-monthly'
-  | 'custom';
-
-interface TemporalPatternOption {
-  id: TemporalPattern;
-  label: string;
-  windowInterval: number;
-  windowUnit: 'weeks' | 'months' | 'years';
-  sliceInterval: number;
-  sliceUnit: 'days' | 'weeks' | 'months' | 'years';
-}
-
-const TEMPORAL_PATTERNS: TemporalPatternOption[] = [
-  {
-    id: 'monthly-weekly',
-    label: 'Monthly mosaics, weekly slices',
-    windowInterval: 1,
-    windowUnit: 'months',
-    sliceInterval: 1,
-    sliceUnit: 'weeks',
-  },
-  {
-    id: 'monthly-monthly',
-    label: 'Monthly mosaics, one image per month',
-    windowInterval: 1,
-    windowUnit: 'months',
-    sliceInterval: 1,
-    sliceUnit: 'months',
-  },
-  {
-    id: 'weekly-weekly',
-    label: 'Weekly mosaics',
-    windowInterval: 1,
-    windowUnit: 'weeks',
-    sliceInterval: 1,
-    sliceUnit: 'weeks',
-  },
-  {
-    id: 'yearly-monthly',
-    label: 'Yearly mosaics, monthly slices',
-    windowInterval: 1,
-    windowUnit: 'years',
-    sliceInterval: 1,
-    sliceUnit: 'months',
-  },
-];
 
 const AdvancedToggle = ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
   <div className="flex justify-end">
@@ -351,9 +366,12 @@ export const CatalogBrowser = ({
             setItemSort('cloud_cover_asc');
             setCoverItemSort('cloud_cover_asc');
           }
-          // For imagery collections (those with cloud cover), enable custom cover by default
-          if (col.has_cloud_cover) {
-            setCoverMode('custom');
+          if (preset.temporalPattern) {
+            applyTemporalPattern(preset.temporalPattern);
+          }
+          const coverMode = preset.coverMode ?? (col.has_cloud_cover ? 'custom' : 'nth');
+          setCoverMode(coverMode);
+          if (coverMode === 'custom') {
             setCoverVisualizations(buildInitialVisualizations(col.id, 'first'));
             setActiveCoverVizIndex(0);
           }


### PR DESCRIPTION
## What

The temporal structure presets in the imagery catalog browser mixed two abstractions - "Monthly mosaics, weekly slices" describes the data, while "Monthly mosaics, one image per month" describes what the annotator gets. Non-technical users had to already know what a mosaic and a slice were to pick correctly.

All four labels now answer the same two questions in the same order: which timeline the annotator steps through, and whether there is a choice of images inside each step.

| Before | After |
| --- | --- |
| Monthly mosaics, weekly slices | Month by month, with weekly images to choose from |
| Monthly mosaics, one image per month | Month by month, one image per month |
| Weekly mosaics | Week by week, one image per week |
| Yearly mosaics, monthly slices | Year by year, with monthly images to choose from |

"Weekly mosaics" was the worst of these - it implied a choice of images existed inside each week. There isn't one, so it now says so.

## NAIP preset

NAIP flies each state roughly every 2-3 years and carries no cloud metadata, but it inherited the form default of monthly windows sliced into weeks - so most slices were empty. It now defaults to yearly windows with the first slice as cover.

This needed a new `yearly-yearly` pattern ("Year by year, one image per year"); the closest existing option would have cut each year into 12 mostly-empty months.

Presets can now declare `temporalPattern` and `coverMode`. Cover selection reads `preset.coverMode` first and falls back to the previous `has_cloud_cover` heuristic, so presets state their intent instead of inheriting it implicitly. Every other preset omits both fields and keeps current behaviour.

## Testing

`tsc --noEmit`, eslint, and prettier pass on the changed file. No automated test covers `TEMPORAL_PATTERNS` or the preset defaults.

Not verified against a live NAIP campaign - worth a manual check that a NAIP source produces one window per year with a single highlighted cover slice before merging.